### PR TITLE
CHEF-25079 - Replace CONTRIBUTING.md file with inactive template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # This Project Has Been Archived and is Not Accepting Contributions
 
-Thank you for your interest in contributing to this project! However, it has reached the end of its lifecycle, and is longer accepting contributions. If you are interested in contributing to other Chef projects, please see [Contributing to Progress Chef Projects](https://chef.github.io/chef-oss-practices/contributors/guide/).
+Thank you for your interest in contributing to this project! However, it has reached the end of its lifecycle, and is no longer accepting contributions. If you are interested in contributing to other Chef projects, please see [Contributing to Progress Chef Projects](https://chef.github.io/chef-oss-practices/contributors/guide/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,3 @@
-Please refer to
-https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
+# This Project Has Been Archived and is Not Accepting Contributions
+
+Thank you for your interest in contributing to this project! However, it has reached the end of its lifecycle, and is longer accepting contributions. If you are interested in contributing to other Chef projects, please see [Contributing to Progress Chef Projects](https://chef.github.io/chef-oss-practices/contributors/guide/).


### PR DESCRIPTION
This repo is being archived and is no longer accepting contributions.
Replace CONTRIBUTING.md file with standard template indicating that the repo has been archived and is no longer accepting contributions.
This pull request replaces the existing CONTRIBUTING.md file with the standard template for the inactive projects.  As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025), when a repo is formally archived, we are replacing all the different contributing guides with a standard template that links to a message about archived repos.
The link provided in the template may not function at the time this PR is opened, in which case this PR is intended to remain in Draft status if the repo permits; in any case it should not be merged until the link is live.